### PR TITLE
Check size before usb transfer in CDC ACM read call back

### DIFF
--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -302,8 +302,10 @@ static void cdc_acm_read_cb(uint8_t ep, int size, void *priv)
 	}
 
 done:
-	usb_transfer(ep, dev_data->rx_buf, sizeof(dev_data->rx_buf),
-		     USB_TRANS_READ, cdc_acm_read_cb, dev_data);
+	if (size > 0) {
+		usb_transfer(ep, dev_data->rx_buf, sizeof(dev_data->rx_buf),
+			USB_TRANS_READ, cdc_acm_read_cb, dev_data);
+	}
 }
 
 /**


### PR DESCRIPTION
Setting usb as composite of usb acm and dfu causes MPU fault error during firmware update. To prevent MPU fault, size check is necessary before usb_transfer.